### PR TITLE
✨ DateTimeCollection

### DIFF
--- a/src/ObjectCollection/DateTime/ContainsDateTimeNullableValueTrait.php
+++ b/src/ObjectCollection/DateTime/ContainsDateTimeNullableValueTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\ObjectCollection\DateTime;
+
+trait ContainsDateTimeNullableValueTrait
+{
+    public function containsDateTimeValue(\DateTimeInterface $dateTime): bool
+    {
+        foreach ($this->toArray() as $value) {
+            if (
+                $value === null
+                || ($dateTime->getTimestamp() + $dateTime->getOffset())
+                !== ($value->getTimestamp() + $value->getOffset())
+            ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /** @return array<?\DateTimeInterface> */
+    abstract protected function toArray(): array;
+}

--- a/src/ObjectCollection/DateTime/ContainsDateTimeValueTrait.php
+++ b/src/ObjectCollection/DateTime/ContainsDateTimeValueTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\ObjectCollection\DateTime;
+
+trait ContainsDateTimeValueTrait
+{
+    public function containsDateTimeValue(\DateTimeInterface $dateTime): bool
+    {
+        foreach ($this->toArray() as $value) {
+            if (
+                ($dateTime->getTimestamp() + $dateTime->getOffset())
+                !== ($value->getTimestamp() + $value->getOffset())
+            ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /** @return array<\DateTimeInterface> */
+    abstract protected function toArray(): array;
+}

--- a/src/ObjectCollection/DateTimeCollection.php
+++ b/src/ObjectCollection/DateTimeCollection.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Steevanb\PhpCollection\ObjectCollection;
 
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeValueTrait;
+
 /** @extends AbstractObjectCollection<\DateTime> */
 class DateTimeCollection extends AbstractObjectCollection
 {
+    use ContainsDateTimeValueTrait;
+
     /** @codeCoverageIgnore */
     public static function getValueFqcn(): string
     {

--- a/src/ObjectCollection/DateTimeImmutableCollection.php
+++ b/src/ObjectCollection/DateTimeImmutableCollection.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Steevanb\PhpCollection\ObjectCollection;
 
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeValueTrait;
+
 /** @extends AbstractObjectCollection<\DateTimeImmutable> */
 class DateTimeImmutableCollection extends AbstractObjectCollection
 {
+    use ContainsDateTimeValueTrait;
+
     /** @codeCoverageIgnore */
     public static function getValueFqcn(): string
     {

--- a/src/ObjectCollection/DateTimeImmutableNullableCollection.php
+++ b/src/ObjectCollection/DateTimeImmutableNullableCollection.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Steevanb\PhpCollection\ObjectCollection;
 
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeNullableValueTrait;
+
 /** @extends AbstractObjectNullableCollection<\DateTimeImmutable|null> */
 class DateTimeImmutableNullableCollection extends AbstractObjectNullableCollection
 {
+    use ContainsDateTimeNullableValueTrait;
+
     /** @codeCoverageIgnore */
     public static function getValueFqcn(): string
     {

--- a/src/ObjectCollection/DateTimeInterfaceCollection.php
+++ b/src/ObjectCollection/DateTimeInterfaceCollection.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Steevanb\PhpCollection\ObjectCollection;
 
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeValueTrait;
+
 /** @extends AbstractObjectCollection<\DateTimeInterface> */
 class DateTimeInterfaceCollection extends AbstractObjectCollection
 {
+    use ContainsDateTimeValueTrait;
+
     /** @codeCoverageIgnore */
     public static function getValueFqcn(): string
     {

--- a/src/ObjectCollection/DateTimeInterfaceNullableCollection.php
+++ b/src/ObjectCollection/DateTimeInterfaceNullableCollection.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Steevanb\PhpCollection\ObjectCollection;
 
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeNullableValueTrait;
+
 /** @extends AbstractObjectNullableCollection<\DateTimeInterface|null> */
 class DateTimeInterfaceNullableCollection extends AbstractObjectNullableCollection
 {
+    use ContainsDateTimeNullableValueTrait;
+
     /** @codeCoverageIgnore */
     public static function getValueFqcn(): string
     {

--- a/src/ObjectCollection/DateTimeNullableCollection.php
+++ b/src/ObjectCollection/DateTimeNullableCollection.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Steevanb\PhpCollection\ObjectCollection;
 
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeNullableValueTrait;
+
 /** @extends AbstractObjectNullableCollection<\DateTime|null> */
 class DateTimeNullableCollection extends AbstractObjectNullableCollection
 {
+    use ContainsDateTimeNullableValueTrait;
+
     /** @codeCoverageIgnore */
     public static function getValueFqcn(): string
     {

--- a/tests/Unit/ObjectCollection/DateTime/ContainsDateTimeValue/TraitUsageTest.php
+++ b/tests/Unit/ObjectCollection/DateTime/ContainsDateTimeValue/TraitUsageTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTime\ContainsDateTimeValue;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeNullableValueTrait;
+use Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeValueTrait;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeCollection;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableCollection;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableNullableCollection;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeInterfaceCollection;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeInterfaceNullableCollection;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeNullableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeValueTrait
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTime\ContainsDateTimeNullableValueTrait
+ * @internal
+ */
+final class TraitUsageTest extends TestCase
+{
+    /**
+     * @dataProvider provideCollectionUsingTrait
+     * @param class-string $class
+     */
+    public function testUsingTrait(string $class): void
+    {
+        $reflectionCollection = new \ReflectionClass($class);
+        static::assertContains(
+            needle: ContainsDateTimeValueTrait::class,
+            haystack: array_map(
+                static fn (\ReflectionClass $reflectionTrait): string => $reflectionTrait->getName(),
+                $reflectionCollection->getTraits()
+            )
+        );
+    }
+
+    /**
+     * @dataProvider provideCollectionUsingNullableTrait
+     * @param class-string $class
+     */
+    public function testUsingNullableTrait(string $class): void
+    {
+        $reflectionCollection = new \ReflectionClass($class);
+        static::assertContains(
+            needle: ContainsDateTimeNullableValueTrait::class,
+            haystack: array_map(
+                static fn (\ReflectionClass $reflectionTrait): string => $reflectionTrait->getName(),
+                $reflectionCollection->getTraits()
+            )
+        );
+    }
+
+    /** @return iterable<string, array{class: class-string}> */
+    public static function provideCollectionUsingTrait(): iterable
+    {
+        yield 'ContainsDateTimeValueTrait_is_used_by_DateTimeCollection' => [
+            'class' => DateTimeCollection::class,
+        ];
+        yield 'ContainsDateTimeValueTrait_is_used_by_DateTimeImmutableCollection' => [
+            'class' => DateTimeImmutableCollection::class,
+        ];
+        yield 'ContainsDateTimeValueTrait_is_used_by_DateTimeInterfaceCollection' => [
+            'class' => DateTimeInterfaceCollection::class,
+        ];
+    }
+
+    /** @return iterable<string, array{class: class-string}> */
+    public static function provideCollectionUsingNullableTrait(): iterable
+    {
+        yield 'ContainsDateTimeNullableValueTrait_is_used_by_DateTimeNullableCollection' => [
+            'class' => DateTimeNullableCollection::class,
+        ];
+        yield 'ContainsDateTimeNullableValueTrait_is_used_by_DateTimeImmutableNullableCollection' => [
+            'class' => DateTimeImmutableNullableCollection::class,
+        ];
+        yield 'ContainsDateTimeNullableValueTrait_is_used_by_DateTimeInterfaceNullableCollection' => [
+            'class' => DateTimeInterfaceNullableCollection::class,
+        ];
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeCollection/ContainsDateTimeValueTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeCollection/ContainsDateTimeValueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeCollection::containsDateTimeValue
+ * @internal
+ */
+final class ContainsDateTimeValueTest extends TestCase
+{
+    public function testContainsDateTimeValue(): void
+    {
+        $dateTimeA = new \DateTime();
+        $dateTimeCopy = $dateTimeA;
+        // Asserting different timestamps
+        $dateTimeB = (new \DateTime())->add(new \DateInterval('PT1S'));
+        $dateTimeClone = clone $dateTimeA;
+        $dateTimeSameTime = (new \DateTime())->setTimestamp($dateTimeA->getTimestamp());
+
+        $dateTimeCollection = new DateTimeCollection([$dateTimeA]);
+
+        static::assertTrue($dateTimeCollection->containsDateTimeValue($dateTimeA));
+        static::assertTrue($dateTimeCollection->containsDateTimeValue($dateTimeCopy));
+        static::assertFalse($dateTimeCollection->containsDateTimeValue($dateTimeB));
+        static::assertTrue($dateTimeCollection->containsDateTimeValue($dateTimeClone));
+        static::assertTrue($dateTimeCollection->containsDateTimeValue($dateTimeSameTime));
+    }
+
+    public function testContainsDateTimeValueWithTimezone(): void
+    {
+        $dateTime = new \DateTime('2024-07-14 12:00:00');
+        $dateTimeB = clone $dateTime;
+        $dateTimeC = clone $dateTime;
+        $dateTimeD = clone $dateTime;
+
+        // Setting timezones
+        $dateTime->setTimezone(new \DateTimeZone('+0800'));
+        $dateTimeB->setTimezone(new \DateTimeZone('+0600'));
+        $dateTimeC->setTimezone(new \DateTimeZone('-0600'));
+        $dateTimeD->setTimezone($dateTime->getTimezone());
+
+        $dateTimeCollection = new DateTimeCollection([$dateTime]);
+
+        static::assertFalse($dateTimeCollection->containsDateTimeValue($dateTimeB));
+        static::assertFalse($dateTimeCollection->containsDateTimeValue($dateTimeC));
+        static::assertTrue($dateTimeCollection->containsDateTimeValue($dateTimeD));
+    }
+
+    public function testContainsDateTimeValueAfterClone(): void
+    {
+        $dateTime = new \DateTime();
+
+        $dateTimeCollection = (new DateTimeCollection([$dateTime]));
+        $dateTimeCollectionClone = clone ($dateTimeCollection);
+
+        static::assertTrue($dateTimeCollection->containsDateTimeValue($dateTime));
+        static::assertTrue($dateTimeCollectionClone->containsDateTimeValue($dateTime));
+    }
+
+    public function testContainsDateTimeValueAfterMerge(): void
+    {
+        $dateTime = new \DateTime();
+
+        static::assertTrue(
+            (new DateTimeCollection([$dateTime]))
+                ->merge(new DateTimeCollection([new \DateTime()]))
+                ->containsDateTimeValue($dateTime)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeCollection/ContainsTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeCollection/ContainsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeCollection::contains
+ * @internal
+ */
+final class ContainsTest extends TestCase
+{
+    public function testContains(): void
+    {
+        $dateTimeA = new \DateTime();
+        $dateTimeCopy = $dateTimeA;
+        $dateTimeB = new \DateTime();
+        $dateTimeClone = clone $dateTimeA;
+        $dateTimeSameTime = (new \DateTime())->setTimestamp($dateTimeA->getTimestamp());
+
+        $dateTimeCollection = new DateTimeCollection([$dateTimeA]);
+
+        static::assertTrue($dateTimeCollection->contains($dateTimeA));
+        static::assertTrue($dateTimeCollection->contains($dateTimeCopy));
+        static::assertFalse($dateTimeCollection->contains($dateTimeB));
+        static::assertFalse($dateTimeCollection->contains($dateTimeClone));
+        static::assertFalse($dateTimeCollection->contains($dateTimeSameTime));
+    }
+
+    public function testContainsAfterClone(): void
+    {
+        $dateTime = new \DateTime();
+
+        $dateTimeCollection = (new DateTimeCollection([$dateTime]));
+        $dateTimeCollectionClone = clone ($dateTimeCollection);
+
+        static::assertTrue($dateTimeCollection->contains($dateTime));
+        static::assertTrue($dateTimeCollectionClone->contains($dateTime));
+    }
+
+    public function testContainsAfterMerge(): void
+    {
+        $dateTime = new \DateTime();
+
+        static::assertTrue(
+            (new DateTimeCollection([$dateTime]))
+                ->merge(new DateTimeCollection([new \DateTime()]))
+                ->contains($dateTime)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeCollection/TypeTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeCollection/TypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\{
+    Exception\InvalidTypeException,
+    ObjectCollection\DateTimeCollection
+};
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeCollection
+ * @internal
+ */
+final class TypeTest extends TestCase
+{
+    public function testAllowDateTime(): void
+    {
+        $dateTime = new \DateTime();
+        $dateTimeCollection = new DateTimeCollection([$dateTime]);
+
+        static::assertCount(expectedCount: 1, haystack: $dateTimeCollection);
+        static::assertSame(expected: $dateTime, actual: $dateTimeCollection->get(0));
+    }
+
+    /** @dataProvider provideInvalidType */
+    public function testInvalidType(mixed $value): void
+    {
+        $this->expectException(InvalidTypeException::class);
+        /** @phpstan-ignore-next-line Parameter #1 $values ... constructor expects ... array<int, mixed> given. */
+        new DateTimeCollection([$value]);
+    }
+
+    /** @return iterable<string, mixed> */
+    public static function provideInvalidType(): iterable
+    {
+        yield 'it_throws_invalid_type_exception_on_null_value' => [
+            'value' => null,
+        ];
+        yield 'it_throws_invalid_type_exception_on_true_value' => [
+            'value' => true,
+        ];
+        yield 'it_throws_invalid_type_exception_on_false_value' => [
+            'value' => false,
+        ];
+        yield 'it_throws_invalid_type_exception_on_string_value' => [
+            'value' => '--value--',
+        ];
+        yield 'it_throws_invalid_type_exception_on_integer_value' => [
+            'value' => 42,
+        ];
+        yield 'it_throws_invalid_type_exception_on_float_value' => [
+            'value' => 3.14,
+        ];
+        yield 'it_throws_invalid_type_exception_on_empty_array_value' => [
+            'value' => [],
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTime_array_value' => [
+            'value' => [new \DateTime()],
+        ];
+        yield 'it_throws_invalid_type_exception_on_object_value' => [
+            'value' => new class() {
+            },
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTimeCollection_value' => [
+            'value' => new DateTimeCollection(),
+        ];
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeImmutableCollection/ContainsDateTimeValueTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeImmutableCollection/ContainsDateTimeValueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeImmutableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableCollection::containsDateTimeValue
+ * @internal
+ */
+final class ContainsDateTimeValueTest extends TestCase
+{
+    public function testContainsDateTimeValue(): void
+    {
+        $dateTimeImmutableA = new \DateTimeImmutable();
+        $dateTimeImmutableCopy = $dateTimeImmutableA;
+        // Asserting different timestamps
+        $dateTimeImmutableB = (new \DateTimeImmutable())->add(new \DateInterval('PT1S'));
+        $dateTimeImmutableClone = clone $dateTimeImmutableA;
+        $dateTimeImmutableSameTime = (new \DateTimeImmutable())->setTimestamp($dateTimeImmutableA->getTimestamp());
+
+        $dateTimeImmutableCollection = new DateTimeImmutableCollection([$dateTimeImmutableA]);
+
+        static::assertTrue($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableA));
+        static::assertTrue($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableCopy));
+        static::assertFalse($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableB));
+        static::assertTrue($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableClone));
+        static::assertTrue($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableSameTime));
+    }
+
+    public function testContainsDateTimeValueWithTimezone(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable('2024-07-14 12:00:00');
+        $dateTimeImmutableB = clone $dateTimeImmutable;
+        $dateTimeImmutableC = clone $dateTimeImmutable;
+        $dateTimeImmutableD = clone $dateTimeImmutable;
+
+        // Setting timezones
+        $dateTimeImmutable = $dateTimeImmutable->setTimezone(new \DateTimeZone('+0800'));
+        $dateTimeImmutableB = $dateTimeImmutableB->setTimezone(new \DateTimeZone('+0600'));
+        $dateTimeImmutableC = $dateTimeImmutableC->setTimezone(new \DateTimeZone('-0600'));
+        $dateTimeImmutableD = $dateTimeImmutableD->setTimezone($dateTimeImmutable->getTimezone());
+
+        $dateTimeImmutableCollection = new DateTimeImmutableCollection([$dateTimeImmutable]);
+
+        static::assertFalse($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableB));
+        static::assertFalse($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableC));
+        static::assertTrue($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutableD));
+    }
+
+    public function testContainsDateTimeValueAfterClone(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        $dateTimeImmutableCollection = (new DateTimeImmutableCollection([$dateTimeImmutable]));
+        $dateTimeImmutableCollectionClone = clone ($dateTimeImmutableCollection);
+
+        static::assertTrue($dateTimeImmutableCollection->containsDateTimeValue($dateTimeImmutable));
+        static::assertTrue($dateTimeImmutableCollectionClone->containsDateTimeValue($dateTimeImmutable));
+    }
+
+    public function testContainsDateTimeValueAfterMerge(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        static::assertTrue(
+            (new DateTimeImmutableCollection([$dateTimeImmutable]))
+                ->merge(new DateTimeImmutableCollection([new \DateTimeImmutable()]))
+                ->containsDateTimeValue($dateTimeImmutable)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeImmutableCollection/ContainsTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeImmutableCollection/ContainsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeImmutableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableCollection::contains
+ * @internal
+ */
+final class ContainsTest extends TestCase
+{
+    public function testContains(): void
+    {
+        $dateTimeImmutableA = new \DateTimeImmutable();
+        $dateTimeImmutableCopy = $dateTimeImmutableA;
+        $dateTimeImmutableB = new \DateTimeImmutable();
+        $dateTimeImmutableClone = clone $dateTimeImmutableA;
+        $dateTimeImmutableSameTime = (new \DateTimeImmutable())->setTimestamp($dateTimeImmutableA->getTimestamp());
+
+        $dateTimeImmutableCollection = new DateTimeImmutableCollection([$dateTimeImmutableA]);
+
+        static::assertTrue($dateTimeImmutableCollection->contains($dateTimeImmutableA));
+        static::assertTrue($dateTimeImmutableCollection->contains($dateTimeImmutableCopy));
+        static::assertFalse($dateTimeImmutableCollection->contains($dateTimeImmutableB));
+        static::assertFalse($dateTimeImmutableCollection->contains($dateTimeImmutableClone));
+        static::assertFalse($dateTimeImmutableCollection->contains($dateTimeImmutableSameTime));
+    }
+
+    public function testContainsAfterClone(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        $dateTimeImmutableCollection = (new DateTimeImmutableCollection([$dateTimeImmutable]));
+        $dateTimeImmutableCollectionClone = clone ($dateTimeImmutableCollection);
+
+        static::assertTrue($dateTimeImmutableCollection->contains($dateTimeImmutable));
+        static::assertTrue($dateTimeImmutableCollectionClone->contains($dateTimeImmutable));
+    }
+
+    public function testContainsAfterMerge(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        static::assertTrue(
+            (new DateTimeImmutableCollection([$dateTimeImmutable]))
+                ->merge(new DateTimeImmutableCollection([new \DateTimeImmutable()]))
+                ->contains($dateTimeImmutable)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeImmutableCollection/TypeTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeImmutableCollection/TypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeImmutableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\{
+    Exception\InvalidTypeException,
+    ObjectCollection\DateTimeImmutableCollection
+};
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableCollection
+ * @internal
+ */
+final class TypeTest extends TestCase
+{
+    public function testAllowDateTimeImmutable(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+        $dateTimeImmutableCollection = new DateTimeImmutableCollection([$dateTimeImmutable]);
+
+        static::assertCount(expectedCount: 1, haystack: $dateTimeImmutableCollection);
+        static::assertSame(expected: $dateTimeImmutable, actual: $dateTimeImmutableCollection->get(0));
+    }
+
+    /** @dataProvider provideInvalidType */
+    public function testInvalidType(mixed $value): void
+    {
+        $this->expectException(InvalidTypeException::class);
+        /** @phpstan-ignore-next-line Parameter #1 $values ... constructor expects ... array<int, mixed> given. */
+        new DateTimeImmutableCollection([$value]);
+    }
+
+    /** @return iterable<string, mixed> */
+    public static function provideInvalidType(): iterable
+    {
+        yield 'it_throws_invalid_type_exception_on_null_value' => [
+            'value' => null,
+        ];
+        yield 'it_throws_invalid_type_exception_on_true_value' => [
+            'value' => true,
+        ];
+        yield 'it_throws_invalid_type_exception_on_false_value' => [
+            'value' => false,
+        ];
+        yield 'it_throws_invalid_type_exception_on_string_value' => [
+            'value' => '--value--',
+        ];
+        yield 'it_throws_invalid_type_exception_on_integer_value' => [
+            'value' => 42,
+        ];
+        yield 'it_throws_invalid_type_exception_on_float_value' => [
+            'value' => 3.14,
+        ];
+        yield 'it_throws_invalid_type_exception_on_empty_array_value' => [
+            'value' => [],
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTimeImmutable_array_value' => [
+            'value' => [new \DateTimeImmutable()],
+        ];
+        yield 'it_throws_invalid_type_exception_on_object_value' => [
+            'value' => new class() {
+            },
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTimeImmutableCollection_value' => [
+            'value' => new DateTimeImmutableCollection(),
+        ];
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeImmutableNullableCollection/ContainsDateTimeValueTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeImmutableNullableCollection/ContainsDateTimeValueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeImmutableNullableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableNullableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableNullableCollection::containsDateTimeValue
+ * @internal
+ */
+final class ContainsDateTimeValueTest extends TestCase
+{
+    public function testContainsDateTimeValue(): void
+    {
+        $dateTimeImmutableA = new \DateTimeImmutable();
+        $dateTimeImmutableCopy = $dateTimeImmutableA;
+        // Asserting different timestamps
+        $dateTimeImmutableB = (new \DateTimeImmutable())->add(new \DateInterval('PT1S'));
+        $dateTimeImmutableClone = clone $dateTimeImmutableA;
+        $dateTimeImmutableSameTime = (new \DateTimeImmutable())->setTimestamp($dateTimeImmutableA->getTimestamp());
+
+        $dateTimeImmutableNullableCollection = new DateTimeImmutableNullableCollection([$dateTimeImmutableA, null]);
+
+        static::assertTrue($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableA));
+        static::assertTrue($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableCopy));
+        static::assertFalse($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableB));
+        static::assertTrue($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableClone));
+        static::assertTrue($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableSameTime));
+    }
+
+    public function testContainsDateTimeValueWithTimezone(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable('2024-07-14 12:00:00');
+        $dateTimeImmutableB = clone $dateTimeImmutable;
+        $dateTimeImmutableC = clone $dateTimeImmutable;
+        $dateTimeImmutableD = clone $dateTimeImmutable;
+
+        // Setting timezones
+        $dateTimeImmutable = $dateTimeImmutable->setTimezone(new \DateTimeZone('+0800'));
+        $dateTimeImmutableB = $dateTimeImmutableB->setTimezone(new \DateTimeZone('+0600'));
+        $dateTimeImmutableC = $dateTimeImmutableC->setTimezone(new \DateTimeZone('-0600'));
+        $dateTimeImmutableD = $dateTimeImmutableD->setTimezone($dateTimeImmutable->getTimezone());
+
+        $dateTimeImmutableNullableCollection = new DateTimeImmutableNullableCollection([$dateTimeImmutable]);
+
+        static::assertFalse($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableB));
+        static::assertFalse($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableC));
+        static::assertTrue($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutableD));
+    }
+
+    public function testContainsDateTimeValueAfterClone(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        $dateTimeImmutableNullableCollection = (new DateTimeImmutableNullableCollection([$dateTimeImmutable]));
+        $dateTimeImmutableNullableCollectionClone = clone ($dateTimeImmutableNullableCollection);
+
+        static::assertTrue($dateTimeImmutableNullableCollection->containsDateTimeValue($dateTimeImmutable));
+        static::assertTrue($dateTimeImmutableNullableCollectionClone->containsDateTimeValue($dateTimeImmutable));
+    }
+
+    public function testContainsDateTimeValueAfterMerge(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        static::assertTrue(
+            (new DateTimeImmutableNullableCollection([$dateTimeImmutable]))
+                ->merge(new DateTimeImmutableNullableCollection([new \DateTimeImmutable()]))
+                ->containsDateTimeValue($dateTimeImmutable)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeImmutableNullableCollection/ContainsTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeImmutableNullableCollection/ContainsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeImmutableNullableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableNullableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableNullableCollection::contains
+ * @internal
+ */
+final class ContainsTest extends TestCase
+{
+    public function testContains(): void
+    {
+        $dateTimeImmutableA = new \DateTimeImmutable();
+        $dateTimeImmutableCopy = $dateTimeImmutableA;
+        $dateTimeImmutableB = new \DateTimeImmutable();
+        $dateTimeImmutableClone = clone $dateTimeImmutableA;
+        $dateTimeImmutableSameTime = (new \DateTimeImmutable())->setTimestamp($dateTimeImmutableA->getTimestamp());
+
+        $dateTimeImmutableNullableCollection = new DateTimeImmutableNullableCollection([$dateTimeImmutableA, null]);
+
+        static::assertTrue($dateTimeImmutableNullableCollection->contains($dateTimeImmutableA));
+        static::assertTrue($dateTimeImmutableNullableCollection->contains($dateTimeImmutableCopy));
+        static::assertFalse($dateTimeImmutableNullableCollection->contains($dateTimeImmutableB));
+        static::assertFalse($dateTimeImmutableNullableCollection->contains($dateTimeImmutableClone));
+        static::assertFalse($dateTimeImmutableNullableCollection->contains($dateTimeImmutableSameTime));
+        static::assertTrue($dateTimeImmutableNullableCollection->contains(null));
+    }
+
+    public function testContainsAfterClone(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        $dateTimeImmutableNullableCollection = (new DateTimeImmutableNullableCollection([$dateTimeImmutable]));
+        $dateTimeImmutableNullableCollectionClone = clone ($dateTimeImmutableNullableCollection);
+
+        static::assertTrue($dateTimeImmutableNullableCollection->contains($dateTimeImmutable));
+        static::assertTrue($dateTimeImmutableNullableCollectionClone->contains($dateTimeImmutable));
+    }
+
+    public function testContainsAfterMerge(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+
+        static::assertTrue(
+            (new DateTimeImmutableNullableCollection([$dateTimeImmutable]))
+                ->merge(new DateTimeImmutableNullableCollection([new \DateTimeImmutable()]))
+                ->contains($dateTimeImmutable)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeImmutableNullableCollection/TypeTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeImmutableNullableCollection/TypeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeImmutableNullableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\{
+    Exception\InvalidTypeException,
+    ObjectCollection\DateTimeImmutableNullableCollection
+};
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeImmutableNullableCollection
+ * @internal
+ */
+final class TypeTest extends TestCase
+{
+    public function testAllowDateTimeImmutable(): void
+    {
+        $dateTimeImmutable = new \DateTimeImmutable();
+        $dateTimeImmutableNullableCollection = new DateTimeImmutableNullableCollection([$dateTimeImmutable]);
+
+        static::assertCount(expectedCount: 1, haystack: $dateTimeImmutableNullableCollection);
+        static::assertSame(expected: $dateTimeImmutable, actual: $dateTimeImmutableNullableCollection->get(0));
+    }
+
+    public function testAllowNull(): void
+    {
+        $dateTimeImmutableNullableCollection = new DateTimeImmutableNullableCollection([null]);
+
+        static::assertCount(expectedCount: 1, haystack: $dateTimeImmutableNullableCollection);
+        static::assertNull($dateTimeImmutableNullableCollection->get(0));
+    }
+
+    /** @dataProvider provideInvalidType */
+    public function testInvalidType(mixed $value): void
+    {
+        $this->expectException(InvalidTypeException::class);
+        /** @phpstan-ignore-next-line Parameter #1 $values ... constructor expects ... array<int, mixed> given. */
+        new DateTimeImmutableNullableCollection([$value]);
+    }
+
+    /** @return iterable<string, mixed> */
+    public static function provideInvalidType(): iterable
+    {
+        yield 'it_throws_invalid_type_exception_on_true_value' => [
+            'value' => true,
+        ];
+        yield 'it_throws_invalid_type_exception_on_false_value' => [
+            'value' => false,
+        ];
+        yield 'it_throws_invalid_type_exception_on_string_value' => [
+            'value' => '--value--',
+        ];
+        yield 'it_throws_invalid_type_exception_on_integer_value' => [
+            'value' => 42,
+        ];
+        yield 'it_throws_invalid_type_exception_on_float_value' => [
+            'value' => 3.14,
+        ];
+        yield 'it_throws_invalid_type_exception_on_empty_array_value' => [
+            'value' => [],
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTimeImmutable_array_value' => [
+            'value' => [new \DateTimeImmutable()],
+        ];
+        yield 'it_throws_invalid_type_exception_on_object_value' => [
+            'value' => new class() {
+            },
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTimeImmutableNullableCollection_value' => [
+            'value' => new DateTimeImmutableNullableCollection(),
+        ];
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeNullableCollection/ContainsDateTimeValueTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeNullableCollection/ContainsDateTimeValueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeNullableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeNullableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeNullableCollection::containsDateTimeValue
+ * @internal
+ */
+final class ContainsDateTimeValueTest extends TestCase
+{
+    public function testContainsDateTimeValue(): void
+    {
+        $dateTimeA = new \DateTime();
+        $dateTimeCopy = $dateTimeA;
+        // Asserting different timestamps
+        $dateTimeB = (new \DateTime())->add(new \DateInterval('PT1S'));
+        $dateTimeClone = clone $dateTimeA;
+        $dateTimeSameTime = (new \DateTime())->setTimestamp($dateTimeA->getTimestamp());
+
+        $dateTimeNullableCollection = new DateTimeNullableCollection([$dateTimeA, null]);
+
+        static::assertTrue($dateTimeNullableCollection->containsDateTimeValue($dateTimeA));
+        static::assertTrue($dateTimeNullableCollection->containsDateTimeValue($dateTimeCopy));
+        static::assertFalse($dateTimeNullableCollection->containsDateTimeValue($dateTimeB));
+        static::assertTrue($dateTimeNullableCollection->containsDateTimeValue($dateTimeClone));
+        static::assertTrue($dateTimeNullableCollection->containsDateTimeValue($dateTimeSameTime));
+    }
+
+    public function testContainsDateTimeValueWithTimezone(): void
+    {
+        $dateTime = new \DateTime('2024-07-14 12:00:00');
+        $dateTimeB = clone $dateTime;
+        $dateTimeC = clone $dateTime;
+        $dateTimeD = clone $dateTime;
+
+        // Setting timezones
+        $dateTime->setTimezone(new \DateTimeZone('+0800'));
+        $dateTimeB->setTimezone(new \DateTimeZone('+0600'));
+        $dateTimeC->setTimezone(new \DateTimeZone('-0600'));
+        $dateTimeD->setTimezone($dateTime->getTimezone());
+
+        $dateTimeNullableCollection = new DateTimeNullableCollection([$dateTime]);
+
+        static::assertFalse($dateTimeNullableCollection->containsDateTimeValue($dateTimeB));
+        static::assertFalse($dateTimeNullableCollection->containsDateTimeValue($dateTimeC));
+        static::assertTrue($dateTimeNullableCollection->containsDateTimeValue($dateTimeD));
+    }
+
+    public function testContainsDateTimeValueAfterClone(): void
+    {
+        $dateTime = new \DateTime();
+
+        $dateTimeNullableCollection = (new DateTimeNullableCollection([$dateTime]));
+        $dateTimeNullableCollectionClone = clone ($dateTimeNullableCollection);
+
+        static::assertTrue($dateTimeNullableCollection->containsDateTimeValue($dateTime));
+        static::assertTrue($dateTimeNullableCollectionClone->containsDateTimeValue($dateTime));
+    }
+
+    public function testContainsDateTimeValueAfterMerge(): void
+    {
+        $dateTime = new \DateTime();
+
+        static::assertTrue(
+            (new DateTimeNullableCollection([$dateTime]))
+                ->merge(new DateTimeNullableCollection([new \DateTime()]))
+                ->containsDateTimeValue($dateTime)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeNullableCollection/ContainsTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeNullableCollection/ContainsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeNullableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\ObjectCollection\DateTimeNullableCollection;
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeNullableCollection::contains
+ * @internal
+ */
+final class ContainsTest extends TestCase
+{
+    public function testContains(): void
+    {
+        $dateTimeA = new \DateTime();
+        $dateTimeCopy = $dateTimeA;
+        $dateTimeB = new \DateTime();
+        $dateTimeClone = clone $dateTimeA;
+        $dateTimeSameTime = (new \DateTime())->setTimestamp($dateTimeA->getTimestamp());
+
+        $dateTimeNullableCollection = new DateTimeNullableCollection([$dateTimeA, null]);
+
+        static::assertTrue($dateTimeNullableCollection->contains($dateTimeA));
+        static::assertTrue($dateTimeNullableCollection->contains($dateTimeCopy));
+        static::assertFalse($dateTimeNullableCollection->contains($dateTimeB));
+        static::assertFalse($dateTimeNullableCollection->contains($dateTimeClone));
+        static::assertFalse($dateTimeNullableCollection->contains($dateTimeSameTime));
+        static::assertTrue($dateTimeNullableCollection->contains(null));
+    }
+
+    public function testContainsAfterClone(): void
+    {
+        $dateTime = new \DateTime();
+
+        $dateTimeNullableCollection = (new DateTimeNullableCollection([$dateTime]));
+        $dateTimeNullableCollectionClone = clone ($dateTimeNullableCollection);
+
+        static::assertTrue($dateTimeNullableCollection->contains($dateTime));
+        static::assertTrue($dateTimeNullableCollectionClone->contains($dateTime));
+    }
+
+    public function testContainsAfterMerge(): void
+    {
+        $dateTime = new \DateTime();
+
+        static::assertTrue(
+            (new DateTimeNullableCollection([$dateTime]))
+                ->merge(new DateTimeNullableCollection([new \DateTime()]))
+                ->contains($dateTime)
+        );
+    }
+}

--- a/tests/Unit/ObjectCollection/DateTimeNullableCollection/TypeTest.php
+++ b/tests/Unit/ObjectCollection/DateTimeNullableCollection/TypeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Steevanb\PhpCollection\Tests\Unit\ObjectCollection\DateTimeNullableCollection;
+
+use PHPUnit\Framework\TestCase;
+use Steevanb\PhpCollection\{
+    Exception\InvalidTypeException,
+    ObjectCollection\DateTimeNullableCollection
+};
+
+/**
+ * @covers \Steevanb\PhpCollection\ObjectCollection\DateTimeNullableCollection
+ * @internal
+ */
+final class TypeTest extends TestCase
+{
+    public function testAllowDateTime(): void
+    {
+        $dateTime = new \DateTime();
+        $dateTimeNullableCollection = new DateTimeNullableCollection([$dateTime]);
+
+        static::assertCount(expectedCount: 1, haystack: $dateTimeNullableCollection);
+        static::assertSame(expected: $dateTime, actual: $dateTimeNullableCollection->get(0));
+    }
+
+    public function testAllowNull(): void
+    {
+        $dateTimeNullableCollection = new DateTimeNullableCollection([null]);
+
+        static::assertCount(expectedCount: 1, haystack: $dateTimeNullableCollection);
+        static::assertNull($dateTimeNullableCollection->get(0));
+    }
+
+    /** @dataProvider provideInvalidType */
+    public function testInvalidType(mixed $value): void
+    {
+        $this->expectException(InvalidTypeException::class);
+        /** @phpstan-ignore-next-line Parameter #1 $values ... constructor expects ... array<int, mixed> given. */
+        new DateTimeNullableCollection([$value]);
+    }
+
+    /** @return iterable<string, mixed> */
+    public static function provideInvalidType(): iterable
+    {
+        yield 'it_throws_invalid_type_exception_on_true_value' => [
+            'value' => true,
+        ];
+        yield 'it_throws_invalid_type_exception_on_false_value' => [
+            'value' => false,
+        ];
+        yield 'it_throws_invalid_type_exception_on_string_value' => [
+            'value' => '--value--',
+        ];
+        yield 'it_throws_invalid_type_exception_on_integer_value' => [
+            'value' => 42,
+        ];
+        yield 'it_throws_invalid_type_exception_on_float_value' => [
+            'value' => 3.14,
+        ];
+        yield 'it_throws_invalid_type_exception_on_empty_array_value' => [
+            'value' => [],
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTime_array_value' => [
+            'value' => [new \DateTime()],
+        ];
+        yield 'it_throws_invalid_type_exception_on_object_value' => [
+            'value' => new class() {
+            },
+        ];
+        yield 'it_throws_invalid_type_exception_on_DateTimeNullableCollection_value' => [
+            'value' => new DateTimeNullableCollection(),
+        ];
+    }
+}


### PR DESCRIPTION
✅ **Tested!** upon `\DateTime`

✨ Features
==========

* Define `containsDateTimeValue()` function for all `DateTimeInterfaceCollection`
  - Verify upon "date time + timezone" rather than object hash
  - Same for nullable `\DateTimeInterface`
