### PR TITLE
 Add tests for contains to certify contains() works on the same object, and not only the value of it's properties

### DIFF
--- a/tests/Unit/ObjectCollection/AbstractObjectCollectionTest.php
+++ b/tests/Unit/ObjectCollection/AbstractObjectCollectionTest.php
@@ -52,4 +52,33 @@ final class AbstractObjectCollectionTest extends TestCase
         /** @phpstan-ignore-next-line Parameter #1 $values ... constructor expects ... array<int, null> given. */
         new TestObjectCollection([null]);
     }
+
+    public function testNotContains(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $object3 = new TestObject('value 3');
+        $collection = new TestObjectCollection([$object1, $object2]);
+
+        static::assertFalse($collection->contains($object3));
+    }
+
+    public function testContainsEquals(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $object3 = new TestObject('value 1');
+        $collection = new TestObjectCollection([$object1, $object2]);
+
+        static::assertFalse($collection->contains($object3));
+    }
+
+    public function testContainsSame(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $collection = new TestObjectCollection([$object1, $object2]);
+
+        static::assertTrue($collection->contains($object2));
+    }
 }

--- a/tests/Unit/ObjectCollection/AbstractObjectNullableCollectionTest.php
+++ b/tests/Unit/ObjectCollection/AbstractObjectNullableCollectionTest.php
@@ -50,4 +50,42 @@ final class AbstractObjectNullableCollectionTest extends TestCase
 
         static::assertNull($collection->get(0));
     }
+
+    public function testNotContains(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $object3 = new TestObject('value 3');
+        $collection = new TestObjectNullableCollection([$object1, $object2]);
+
+        static::assertFalse($collection->contains($object3));
+    }
+
+    public function testContainsEquals(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $object3 = new TestObject('value 1');
+        $collection = new TestObjectNullableCollection([$object1, $object2]);
+
+        static::assertFalse($collection->contains($object3));
+    }
+
+    public function testContainsSame(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $collection = new TestObjectNullableCollection([$object1, $object2]);
+
+        static::assertTrue($collection->contains($object2));
+    }
+
+    public function testContainsNull(): void
+    {
+        $object1 = new TestObject('value 1');
+        $object2 = new TestObject('value 2');
+        $collection = new TestObjectNullableCollection([$object1, $object2, null]);
+
+        static::assertTrue($collection->contains(null));
+    }
 }

--- a/tests/Unit/ObjectCollection/TestObject.php
+++ b/tests/Unit/ObjectCollection/TestObject.php
@@ -14,9 +14,4 @@ final class TestObject
     {
         return $this->value;
     }
-
-    public function __toString(): string
-    {
-        return $this->value;
-    }
 }


### PR DESCRIPTION
https://github.com/steevanb/php-collection/issues/144